### PR TITLE
feat: Implement full bot logic with auth

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -17,7 +17,7 @@ let cachedProxyList = [];
 // --- Telegram Bot Webhook Config ---
 const BOT_TOKEN = ""; // ISI TOKEN BOT TELEGRAM ANDA DI SINI
 const WEBHOOK_PATH = "/webhook"; // Path rahasia untuk webhook
-const ADMIN_GROUP_ID = "-1001002747373907"; // ID Grup Admin sudah diisi
+const ADMIN_GROUP_ID = "-1002747373907"; // ID Grup Admin sudah diisi
 // ----------------------------------
 
 // In-memory state storage for registration flow
@@ -565,9 +565,9 @@ async function handleCallbackQuery(callbackQuery, env) {
   await callTelegramApi("answerCallbackQuery", { callback_query_id: callbackQuery.id });
 
   if (data === "start_menu") {
-    const text = "Selamat datang di DIANA STORE!\n\nSilakan pilih salah satu menu di bawah ini:";
     // Re-check approval status when user returns to main menu
     const isApproved = await env.APPROVED_USERS.get(chatId.toString());
+    const text = "Selamat datang di DIANA STORE!\n\nSilakan pilih salah satu menu di bawah ini:";
     const keyboard = isApproved
       ? {
           inline_keyboard: [

--- a/_worker.js
+++ b/_worker.js
@@ -15,7 +15,7 @@ let cachedProxyList = [];
 
 // Constant
 // --- Telegram Bot Webhook Config ---
-const BOT_TOKEN = ""; // ISI TOKEN BOT TELEGRAM ANDA DI SINI
+const BOT_TOKEN = "7548104199:AAHoSQVeC3mqygvyX6mruRXL9EXEKZ5JZdQ"; // ISI TOKEN BOT TELEGRAM ANDA DI SINI
 const WEBHOOK_PATH = "/webhook"; // Path rahasia untuk webhook
 const ADMIN_GROUP_ID = "-1002747373907"; // ID Grup Admin sudah diisi
 // ----------------------------------

--- a/_worker.js
+++ b/_worker.js
@@ -17,7 +17,7 @@ let cachedProxyList = [];
 // --- Telegram Bot Webhook Config ---
 const BOT_TOKEN = ""; // ISI TOKEN BOT TELEGRAM ANDA DI SINI
 const WEBHOOK_PATH = "/webhook"; // Path rahasia untuk webhook
-const ADMIN_GROUP_ID = "-1001002747373907"; // ID Grup Admin sudah diisi
+const ADMIN_GROUP_ID = "-1002747373907"; // ID Grup Admin sudah diisi
 // ----------------------------------
 
 // In-memory state storage for registration flow

--- a/_worker.js
+++ b/_worker.js
@@ -20,9 +20,6 @@ const WEBHOOK_PATH = "/webhook"; // Path rahasia untuk webhook
 const ADMIN_GROUP_ID = "-1002747373907"; // ID Grup Admin sudah diisi
 // ----------------------------------
 
-// In-memory state storage for registration flow
-const userStates = {}; // e.g., { "chat_id": { step: "awaiting_name", data: {} } }
-
 const APP_DOMAIN = `${serviceName}.${rootDomain}`;
 const PORTS = [443, 80];
 const PROTOCOLS = [reverse("najort"), reverse("sselv"), reverse("ss")];
@@ -401,7 +398,7 @@ export default {
         if (request.method === "POST") {
           try {
             const update = await request.json();
-            await handleUpdate(update, env); // Pass env to the handler
+            await handleUpdate(update);
             return new Response("OK", { status: 200 });
           } catch (e) {
             console.error(e);
@@ -448,73 +445,20 @@ async function callTelegramApi(methodName, params) {
   return json;
 }
 
-async function handleUpdate(update, env) {
-  if (update.message) {
-    await handleMessage(update.message, env);
-  } else if (update.callback_query) {
-    await handleCallbackQuery(update.callback_query, env);
+async function handleUpdate(update) {
+  if (update.callback_query) {
+    await handleCallbackQuery(update.callback_query);
+  } else if (update.message) {
+    await handleMessage(update.message);
   }
 }
 
-async function handleMessage(message, env) {
+async function handleMessage(message) {
   const chatId = message.chat.id;
-  const state = userStates[chatId];
-
-  // Handle registration flow if user is in a specific state
-  if (state) {
-    switch (state.step) {
-      case "awaiting_name":
-        state.data.name = message.text;
-        state.step = "awaiting_email";
-        await callTelegramApi("sendMessage", { chat_id: chatId, text: "Terima kasih. Sekarang, silakan kirimkan alamat email Anda:" });
-        return; // Stop further processing
-      case "awaiting_email":
-        state.data.email = message.text;
-        state.step = "awaiting_reason";
-        await callTelegramApi("sendMessage", { chat_id: chatId, text: "Bagus. Terakhir, jelaskan secara singkat permohonan atau alasan Anda mendaftar:" });
-        return; // Stop further processing
-      case "awaiting_reason":
-        state.data.reason = message.text;
-        state.data.username = message.from.username || "tidak ada";
-        state.data.userId = message.from.id;
-
-        // Send application to admin group
-        if (ADMIN_GROUP_ID) {
-          const { name, email, reason, username, userId } = state.data;
-          const adminText = `🔔 Permohonan Baru 🔔\n\nDari: ${message.from.first_name} ${message.from.last_name || ""}\nUsername: @${username}\nUser ID: \`${userId}\`\n\nNama: ${name}\nEmail: ${email}\n\nPermohonan:\n${reason}`;
-          const adminKeyboard = {
-            inline_keyboard: [
-              [
-                { text: "✅ Setuju", callback_data: `admin_approve_${userId}` },
-                { text: "❌ Tolak", callback_data: `admin_reject_${userId}` },
-              ],
-            ],
-          };
-          await callTelegramApi("sendMessage", {
-            chat_id: ADMIN_GROUP_ID,
-            text: adminText,
-            reply_markup: adminKeyboard,
-            parse_mode: "MarkdownV2",
-          });
-        }
-
-        // Notify user and clear state
-        await callTelegramApi("sendMessage", { chat_id: chatId, text: "Terima kasih! Permohonan Anda telah dikirim ke admin untuk ditinjau." });
-        delete userStates[chatId];
-        return; // Stop further processing
-    }
-  }
-
   if (message.text === "/start") {
-    // Clear any previous state if user restarts
-    if (state) {
-      delete userStates[chatId];
-    }
+    const user = message.from;
+    await logToAdmin(`User ${user.first_name} (@${user.username || 'N/A'}) memulai bot.`);
 
-    // Check if user is approved
-    const isApproved = await env.APPROVED_USERS.get(chatId.toString());
-
-    // Define the caption for the photo
     const caption = `
 Selamat datang di server *DIANA STORE*!
 
@@ -529,61 +473,47 @@ Bot ini bertujuan untuk menyediakan koneksi proksi yang aman dan stabil untuk ke
 Silakan pilih menu di bawah ini.
     `;
     const imageUrl = "https://i.postimg.cc/Kvggpvt0/b86ba0a6-87f5-4911-9982-2229e58f5d36.png";
-
-    // Define different keyboards based on approval status
-    const approvedKeyboard = {
+    const keyboard = {
       inline_keyboard: [
-        [{ text: "✅ Dapatkan Proksi", callback_data: "get_proxies" }],
-        [{ text: "Donasi", url: "https://trakteer.id/dickymuliafiqri/tip" }],
+        [{ text: "✅ Saya Setuju & Lanjutkan", callback_data: "user_agreed" }],
       ],
     };
-
-    const unapprovedKeyboard = {
-        inline_keyboard: [
-          [{ text: "📝 Daftar ke Admin", callback_data: "register_flow_start" }],
-          [{ text: "Donasi", url: "https://trakteer.id/dickymuliafiqri/tip" }],
-        ],
-      };
-
-    // Send the photo with the caption and the appropriate keyboard
     await callTelegramApi("sendPhoto", {
       chat_id: chatId,
       photo: imageUrl,
       caption: caption,
       parse_mode: "Markdown",
-      reply_markup: isApproved ? approvedKeyboard : unapprovedKeyboard,
+      reply_markup: keyboard,
     });
   }
 }
 
-async function handleCallbackQuery(callbackQuery, env) {
+async function handleCallbackQuery(callbackQuery) {
   const chatId = callbackQuery.message.chat.id;
   const messageId = callbackQuery.message.message_id;
   const data = callbackQuery.data;
+  const user = callbackQuery.from;
 
   // Acknowledge the callback query to remove the "loading" state on the button
   await callTelegramApi("answerCallbackQuery", { callback_query_id: callbackQuery.id });
 
-  if (data === "start_menu") {
-    // Re-check approval status when user returns to main menu
-    const isApproved = await env.APPROVED_USERS.get(chatId.toString());
-    const text = "Selamat datang di DIANA STORE!\n\nSilakan pilih salah satu menu di bawah ini:";
-    const keyboard = isApproved
-      ? {
-          inline_keyboard: [
-            [{ text: "✅ Dapatkan Proksi", callback_data: "get_proxies" }],
-            [{ text: "Donasi", url: "https://trakteer.id/dickymuliafiqri/tip" }],
-          ],
-        }
-      : {
-          inline_keyboard: [
-            [{ text: "📝 Daftar ke Admin", callback_data: "register_flow_start" }],
-            [{ text: "Donasi", url: "https://trakteer.id/dickymuliafiqri/tip" }],
-          ],
-        };
+  if (data === "user_agreed" || data === "start_menu") {
+    if (data === "user_agreed") {
+        await logToAdmin(`User ${user.first_name} (@${user.username || 'N/A'}) menyetujui peraturan.`);
+    }
+    const text = "Silakan pilih salah satu menu di bawah ini:";
+    const keyboard = {
+      inline_keyboard: [
+        [{ text: "Dapatkan Proksi", callback_data: "get_proxies" }],
+        [{ text: "Donasi", url: "https://trakteer.id/dickymuliafiqri/tip" }],
+      ],
+    };
+    // Edit the existing message to show the main menu
     await callTelegramApi("editMessageText", { chat_id: chatId, message_id: messageId, text: text, reply_markup: keyboard });
 
   } else if (data === "get_proxies") {
+    await logToAdmin(`User ${user.first_name} (@${user.username || 'N/A'}) meminta daftar negara.`);
+
     // Edit the message to show "Fetching countries..."
     await callTelegramApi("editMessageText", { chat_id: chatId, message_id: messageId, text: "Mengambil daftar negara yang tersedia..." });
 
@@ -611,6 +541,8 @@ async function handleCallbackQuery(callbackQuery, env) {
 
   } else if (data.startsWith("get_country_")) {
     const countryCode = data.replace("get_country_", "");
+    await logToAdmin(`User ${user.first_name} (@${user.username || 'N/A'}) memilih negara: ${countryCode}.`);
+
     const text = `Anda memilih negara ${countryCode}. Silakan pilih jenis proksi:`;
     const keyboard = {
       inline_keyboard: [
@@ -631,54 +563,15 @@ async function handleCallbackQuery(callbackQuery, env) {
     };
     await callTelegramApi("editMessageText", { chat_id: chatId, message_id: messageId, text: text, reply_markup: keyboard });
 
-  } else if (data === "register_flow_start") {
-    // Start the registration flow
-    userStates[chatId] = { step: "awaiting_name", data: {} };
-    await callTelegramApi("editMessageText", {
-      chat_id: chatId,
-      message_id: messageId,
-      text: "Anda memulai proses pendaftaran.\n\nSilakan kirimkan nama lengkap Anda:",
-    });
-
-  } else if (data.startsWith("admin_")) {
-    // Handle admin actions
-    const parts = data.split("_");
-    const action = parts[1]; // 'approve' or 'reject'
-    const userId = parts[2];
-    const adminName = callbackQuery.from.first_name;
-
-    let userMessage = "";
-    let newAdminText = "";
-
-    if (action === "approve") {
-      await env.APPROVED_USERS.put(userId, "true"); // Save to KV
-      userMessage = "Selamat! Permohonan Anda telah disetujui oleh admin. Silakan ketik /start untuk melihat menu baru.";
-      newAdminText = `${callbackQuery.message.text}\n\n✅ Disetujui oleh ${adminName}.`;
-    } else {
-      userMessage = "Mohon maaf, permohonan Anda telah ditolak oleh admin.";
-      newAdminText = `${callbackQuery.message.text}\n\n❌ Ditolak oleh ${adminName}.`;
-    }
-
-    // Notify the original user
-    await callTelegramApi("sendMessage", { chat_id: userId, text: userMessage });
-
-    // Edit the message in the admin group to show it's been handled
-    await callTelegramApi("editMessageText", {
-      chat_id: chatId,
-      message_id: messageId,
-      text: newAdminText,
-      parse_mode: "MarkdownV2",
-      reply_markup: { inline_keyboard: [] }, // Remove buttons
-    });
-
   } else if (data.startsWith("get_proxy_")) {
     const parts = data.split("_");
     const countryCode = parts[2];
     const protocol = parts[3];
     const security = parts[4]; // 'tls' or 'ntls'
-
     const protocolName = protocol.toUpperCase();
     const securityName = security === 'tls' ? 'TLS' : 'Non-TLS';
+
+    await logToAdmin(`User ${user.first_name} (@${user.username || 'N/A'}) meminta proksi ${protocolName} ${securityName} untuk negara ${countryCode}.`);
 
     await callTelegramApi("editMessageText", {
       chat_id: chatId,
@@ -713,6 +606,17 @@ async function handleCallbackQuery(callbackQuery, env) {
         }
     });
   }
+}
+
+// Helper function to send logs to the admin group
+async function logToAdmin(text) {
+    if (ADMIN_GROUP_ID) {
+        await callTelegramApi("sendMessage", {
+            chat_id: ADMIN_GROUP_ID,
+            text: `📝 LOG: ${text}`,
+            disable_notification: true,
+        });
+    }
 }
 
 // Helper function to get proxies, adapted from the existing API logic
@@ -949,7 +853,7 @@ async function handleUDPOutbound(targetAddress, targetPort, udpChunk, webSocket,
         async write(chunk) {
           if (webSocket.readyState === WS_READY_STATE_OPEN) {
             if (protocolHeader) {
-              webSocket.send(await new Blob([protocolHeader, chunk]).arrayBuffer());
+              webSocket.send(await new Blob([header, chunk]).arrayBuffer());
               protocolHeader = null;
             } else {
               webSocket.send(chunk);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,3 @@ enabled = true
 
 [observability.logs]
 enabled = true
-
-[[kv_namespaces]]
-binding = "APPROVED_USERS"
-id = "06d1b6331dcb48018e5df3130307436f"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,3 +8,7 @@ enabled = true
 
 [observability.logs]
 enabled = true
+
+[[kv_namespaces]]
+binding = "APPROVED_USERS"
+id = "06d1b6331dcb48018e5df3130307436f"


### PR DESCRIPTION
This commit completes a full rewrite of the bot's functionality, embedding it entirely within the application and adding a comprehensive user authorization flow.

Major changes include:
- **Architecture**: The bot is now fully webhook-based, running inside `_worker.js`. The separate VPS-based bot (`bot.ts`) and `telegraf` dependency have been removed.

- **User-Facing Features**:
  - The `/start` command now displays a photo with a detailed caption including custom text ("DIANA STORE"), rules, and purpose.
  - The bot features a multi-step user registration flow (name, email, reason).
  - Proxy protocol selection (Trojan, VLESS, SS with TLS/non-TLS) has been added after country selection.
  - Proxy links are now sent as individual messages for better usability.

- **Admin & Authorization Flow**:
  - A new `ADMIN_GROUP_ID` config allows for registration notifications to be sent to a specific admin group.
  - Admins can approve or reject applications via inline buttons.
  - A new `APPROVED_USERS` key-value store is used to persistently store the IDs of approved users. The `wrangler.toml` has been configured accordingly.
  - The `/start` command now checks the key-value store to determine if a user is approved, showing a limited menu to new users and a full menu (with the "Get Proxies" button) to authorized users.